### PR TITLE
Updating Gnome Runtime/SDK to version 44

### DIFF
--- a/io.github.santiagocezar.maniatic-launcher.yaml
+++ b/io.github.santiagocezar.maniatic-launcher.yaml
@@ -1,7 +1,7 @@
 
 app-id: io.github.santiagocezar.maniatic-launcher
 runtime: org.gnome.Platform
-runtime-version: "43"
+runtime-version: "44"
 sdk: org.gnome.Sdk
 command: maniatic
 finish-args:


### PR DESCRIPTION
## Description
Updating Gnome Runtime to version 44.

## Motivation and Context
The version 43 of the `org.gnome.Platform` runtime is deprecated and not supported anymore. The `flatpak update` command shows the following:

```
Info: runtime org.gnome.Platform branch 43 is end-of-life, with reason:
   The GNOME 43 runtime is no longer supported as of September 20, 2023
```

## How Has This Been Tested?
I build the application locally and was able to run the game correctly from scratch. That's it, importing the data file and see the game in action afterwards.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.